### PR TITLE
Upgrade Python version and adjust pytest command

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12.9'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -31,7 +31,7 @@ jobs:
           # prevent heavy pyannote tests from running by default in CI
           RUN_HEAVY_PYANNOTE: '0'
         run: |
-          pytest -q
+           python -m pytest tests/
 
   heavy-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updated Python version from 3.11 to 3.12.9 and modactions updateified pytest command.

## Summary by Sourcery

Update CI workflow to use Python 3.12.9 and adjust the test invocation command.

CI:
- Bump GitHub Actions test workflow from Python 3.11 to 3.12.9.
- Change CI test step to run pytest via the Python module entry point with an explicit tests directory.